### PR TITLE
feat: interface definition

### DIFF
--- a/client.go
+++ b/client.go
@@ -32,7 +32,7 @@ type Client[Resource any] struct {
 }
 
 // NewClient create a new client to interact with crud-service
-func NewClient[Resource any](options ClientOptions) (Client[Resource], error) {
+func NewClient[Resource any](options ClientOptions) (CrudClient[Resource], error) {
 	client, err := jsonclient.New(jsonclient.Options{
 		BaseURL: options.BaseURL,
 		Headers: options.convertHeaders(),

--- a/client_test.go
+++ b/client_test.go
@@ -44,7 +44,7 @@ func TestNewClient(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotNil(t, c)
-		require.Equal(t, baseURL, c.client.BaseURL.String())
+		require.Equal(t, baseURL, c.(Client[TestResource]).client.BaseURL.String())
 	})
 
 	t.Run("create new client with default headers to add in request", func(t *testing.T) {
@@ -1170,5 +1170,5 @@ func getClient(t *testing.T) Client[TestResource] {
 	})
 	require.NoError(t, err)
 
-	return client
+	return client.(Client[TestResource])
 }

--- a/interface.go
+++ b/interface.go
@@ -1,0 +1,18 @@
+package crud
+
+import "context"
+
+type CrudClient[Resource any] interface {
+	GetByID(ctx context.Context, id string, options Options) (*Resource, error)
+	List(ctx context.Context, options Options) ([]Resource, error)
+	Count(ctx context.Context, options Options) (int, error)
+	Export(ctx context.Context, options Options) ([]Resource, error)
+	PatchById(ctx context.Context, id string, body PatchBody, options Options) (*Resource, error)
+	PatchMany(ctx context.Context, body PatchBody, options Options) (*Resource, error)
+	PatchBulk(ctx context.Context, body PatchBulkBody, options Options) (int, error)
+	Create(ctx context.Context, resource Resource, options Options) (string, error)
+	CreateMany(ctx context.Context, resources []Resource, options Options) ([]CreatedResource, error)
+	DeleteById(ctx context.Context, id string, options Options) error
+	DeleteMany(ctx context.Context, options Options) (int, error)
+	UpsertOne(ctx context.Context, body UpsertBody, options Options) (*Resource, error)
+}


### PR DESCRIPTION
When dealing with the lib I'd like to be able to use an interface in function definition rather than the actual implementation making it possible to mock it (in a future PR I'll provide a mock implementation to be re-used)